### PR TITLE
Fix memory leak: hold JavaParserFacade cache values weakly

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacade.java
@@ -54,6 +54,7 @@ import com.github.javaparser.symbolsolver.javaparsermodel.declarations.JavaParse
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 import com.github.javaparser.utils.Log;
+import java.lang.ref.WeakReference;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -69,7 +70,18 @@ public class JavaParserFacade {
     private static final DataKey<ResolvedType> TYPE_WITH_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {};
     private static final DataKey<ResolvedType> TYPE_WITHOUT_LAMBDAS_RESOLVED = new DataKey<ResolvedType>() {};
 
-    private static final Map<TypeSolver, JavaParserFacade> instances = new WeakHashMap<>();
+    /**
+     * Cache of facades, keyed by the root {@link TypeSolver}.
+     *
+     * <p>The keys are held weakly. The values <strong>must</strong> be held weakly as well: a
+     * {@link JavaParserFacade} stores its own {@code typeSolver} (the map key) in several final
+     * fields, so a strongly-held value would keep its own weak key permanently reachable. That
+     * self-cycle prevents the {@link WeakHashMap} from ever expiring the entry, pinning the type
+     * solver (and everything reachable from it) for the lifetime of the JVM. Wrapping the value in a
+     * {@link WeakReference} breaks the cycle: once no caller strongly references the facade it can be
+     * collected, the key then becomes weakly reachable, and the entry is evicted.</p>
+     */
+    private static final Map<TypeSolver, WeakReference<JavaParserFacade>> instances = new WeakHashMap<>();
 
     private static final String JAVA_LANG_STRING = String.class.getCanonicalName();
 
@@ -84,7 +96,17 @@ public class JavaParserFacade {
      * @see <a href="https://github.com/javaparser/javaparser/issues/2671">https://github.com/javaparser/javaparser/issues/2671</a>
      */
     public static synchronized JavaParserFacade get(TypeSolver typeSolver) {
-        return instances.computeIfAbsent(typeSolver.getRoot(), JavaParserFacade::new);
+        TypeSolver root = typeSolver.getRoot();
+        WeakReference<JavaParserFacade> ref = instances.get(root);
+        JavaParserFacade facade = ref == null ? null : ref.get();
+        if (facade == null) {
+            // Either no entry yet, or the previously cached facade has been collected (its value is
+            // held only weakly, see #instances). Rebuild it; resolution results are recomputed on
+            // demand, so a fresh facade is functionally equivalent.
+            facade = new JavaParserFacade(root);
+            instances.put(root, new WeakReference<>(facade));
+        }
+        return facade;
     }
 
     /**

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacadeTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/javaparsermodel/JavaParserFacadeTest.java
@@ -23,21 +23,50 @@ package com.github.javaparser.symbolsolver.javaparsermodel;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.javaparser.JavaParserAdapter;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.expr.MethodCallExpr;
 import com.github.javaparser.resolution.Solver;
+import com.github.javaparser.resolution.TypeSolver;
 import com.github.javaparser.resolution.UnsolvedSymbolException;
 import com.github.javaparser.resolution.types.ResolvedType;
 import com.github.javaparser.symbolsolver.resolution.AbstractResolutionTest;
 import com.github.javaparser.symbolsolver.resolution.SymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import java.lang.ref.WeakReference;
 import org.junit.jupiter.api.Test;
 
 class JavaParserFacadeTest extends AbstractResolutionTest {
 
     private final Solver symbolSolver = new SymbolSolver(new ReflectionTypeSolver());
+
+    /**
+     * Regression test for the per-{@link TypeSolver} facade cache leak: {@code instances} is a
+     * {@link java.util.WeakHashMap} whose value (the facade) stores its own key (the type solver) in
+     * final fields. If the value were held strongly, the weak key could never be collected, pinning
+     * the type solver — and, for callers such as KeY, everything reachable from it — for the lifetime
+     * of the JVM. The value is therefore held via a {@link WeakReference}; here we assert that once
+     * the caller drops its strong reference, the cached type solver becomes collectable.
+     */
+    @Test
+    void facadeCacheDoesNotPinItsTypeSolver() throws InterruptedException {
+        TypeSolver typeSolver = new ReflectionTypeSolver();
+        // Populate the cache entry for this solver; deliberately keep no reference to the facade.
+        JavaParserFacade.get(typeSolver);
+        WeakReference<TypeSolver> ref = new WeakReference<>(typeSolver);
+
+        typeSolver = null; // drop the only strong reference held by this test
+
+        boolean collected = false;
+        for (int i = 0; i < 50 && !collected; i++) {
+            System.gc();
+            Thread.sleep(20);
+            collected = ref.get() == null;
+        }
+        assertTrue(collected, "JavaParserFacade cache must not strongly pin its key TypeSolver");
+    }
 
     @Test
     void classToResolvedType_givenPrimitiveShouldBeAReflectionPrimitiveDeclaration() {


### PR DESCRIPTION
## Summary

`JavaParserFacade` caches one facade per root `TypeSolver` in a process-global map:

```java
private static final Map<TypeSolver, JavaParserFacade> instances = new WeakHashMap<>();

public static synchronized JavaParserFacade get(TypeSolver typeSolver) {
    return instances.computeIfAbsent(typeSolver.getRoot(), JavaParserFacade::new);
}
```

The map is a `WeakHashMap` so that entries disappear when their `TypeSolver` key is no longer used.
But each **value** (the `JavaParserFacade`) stores its own **key** (the type solver) in several
`final` fields (`typeSolver`, plus the `TypeExtractor` / `SymbolSolver` / `JavaSymbolSolver` built
from it). A weak key that stays strongly reachable *from its own value* can never become weakly
reachable, so the entry is **never evicted**. The type solver — and everything reachable from it — is
pinned for the lifetime of the JVM.

For any consumer that creates a fresh type solver per unit of work this leaks without bound. KeY,
for instance, builds one type solver per proof, so every loaded proof was retained in full
(~57 MB/proof in our measurements) after disposal, via this cache.

## Fix

Hold the cache **value** in a `WeakReference`, breaking the self-cycle:

```java
private static final Map<TypeSolver, WeakReference<JavaParserFacade>> instances = new WeakHashMap<>();

public static synchronized JavaParserFacade get(TypeSolver typeSolver) {
    TypeSolver root = typeSolver.getRoot();
    WeakReference<JavaParserFacade> ref = instances.get(root);
    JavaParserFacade facade = ref == null ? null : ref.get();
    if (facade == null) {                 // absent, or previously collected
        facade = new JavaParserFacade(root);
        instances.put(root, new WeakReference<>(facade));
    }
    return facade;
}
```

Once a caller drops its strong reference to a facade, the facade becomes collectable, its strong
reference to the key dies, the key becomes weakly reachable, and the `WeakHashMap` entry is evicted.
While a type solver is in active use (the caller keeps it reachable) the entry is retained exactly as
before; the only cost is an occasional, cheap facade rebuild.

`WeakReference` is used deliberately rather than `SoftReference`: soft references are not cleared
until memory pressure, which would let the leak grow to near-OOM before any collection happens.
`clearInstances()` is unchanged and still works.

## Behavioural notes

- No API change. `get()` / `clearInstances()` signatures and semantics are unchanged; only the
  cache's retention strength changes.
- Resolution results are recomputed on demand, so returning a freshly rebuilt facade after a
  collection is functionally equivalent.

## Testing

- New `JavaParserFacadeTest#facadeCacheDoesNotPinItsTypeSolver`: populates the cache for a
  `TypeSolver`, drops the only strong reference, and asserts the solver becomes collectable. It
  **fails on `master`** (solver pinned) and **passes with this change**.
- `JavaParserFacadeTest` + `JavaParserFacadeResolutionTest`: no new failures introduced. (Three
  `StackOverflowError` failures in these classes on this checkout are a separate, pre-existing bug,
  unrelated to this change — fixed independently in #8.)

## Related PRs

- **KeYProject/key#3854** — the consumer-side counterpart. It clears the facade cache on
  `Proof.dispose()` to release leaked proofs against the *currently published* fork artifact. Once a
  fork release containing this PR is picked up there, that workaround can be relaxed (see #3854 for
  details). The two together fully close the ~57 MB/proof leak KeY was seeing.
- **#8** — fixes the three pre-existing `StackOverflowError` test failures mentioned above (a
  regression in method resolution); independent of this memory fix.

