### PR TITLE
Fix StackOverflowError: thread call context through solveMethodAsUsage

### DIFF
--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/javaparsermodel/contexts/MethodCallExprContext.java
@@ -123,7 +123,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
             argumentsTypes.set(i, updatedArgumentType);
         }
 
-        return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this);
+        return solveMethodAsUsage(typeOfScope, name, argumentsTypes, this, invocationContext);
     }
 
     private MethodUsage resolveMethodTypeParametersFromExplicitList(TypeSolver typeSolver, MethodUsage methodUsage) {
@@ -482,7 +482,8 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     }
 
     private Optional<MethodUsage> solveMethodAsUsage(
-            ResolvedTypeVariable tp, String name, List<ResolvedType> argumentsTypes, Context invokationContext) {
+            ResolvedTypeVariable tp, String name, List<ResolvedType> argumentsTypes, Context invokationContext,
+            ResolvedReferenceTypeDeclaration callContext) {
         List<ResolvedTypeParameterDeclaration.Bound> bounds =
                 tp.asTypeParameter().getBounds();
 
@@ -498,7 +499,7 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
 
         for (ResolvedTypeParameterDeclaration.Bound bound : bounds) {
             Optional<MethodUsage> methodUsage =
-                    solveMethodAsUsage(bound.getType(), name, argumentsTypes, invokationContext);
+                    solveMethodAsUsage(bound.getType(), name, argumentsTypes, invokationContext, callContext);
             if (methodUsage.isPresent()) {
                 return methodUsage;
             }
@@ -508,33 +509,40 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
     }
 
     private Optional<MethodUsage> solveMethodAsUsage(
-            ResolvedType type, String name, List<ResolvedType> argumentsTypes, Context invokationContext) {
+            ResolvedType type, String name, List<ResolvedType> argumentsTypes, Context invokationContext,
+            ResolvedReferenceTypeDeclaration callContext) {
         if (type instanceof ResolvedReferenceType) {
-            return solveMethodAsUsage((ResolvedReferenceType) type, name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage((ResolvedReferenceType) type, name, argumentsTypes, invokationContext,
+                    callContext);
         }
         if (type instanceof LazyType) {
-            return solveMethodAsUsage(type.asReferenceType(), name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage(type.asReferenceType(), name, argumentsTypes, invokationContext, callContext);
         }
         if (type instanceof ResolvedTypeVariable) {
-            return solveMethodAsUsage((ResolvedTypeVariable) type, name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage((ResolvedTypeVariable) type, name, argumentsTypes, invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedWildcard) {
             ResolvedWildcard wildcardUsage = (ResolvedWildcard) type;
             if (wildcardUsage.isSuper()) {
-                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext,
+                        callContext);
             }
             if (wildcardUsage.isExtends()) {
-                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(wildcardUsage.getBoundedType(), name, argumentsTypes, invokationContext,
+                        callContext);
             }
             return solveMethodAsUsage(
                     new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject()),
                     name,
                     argumentsTypes,
-                    invokationContext);
+                    invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedLambdaConstraintType) {
             ResolvedLambdaConstraintType constraintType = (ResolvedLambdaConstraintType) type;
-            return solveMethodAsUsage(constraintType.getBound(), name, argumentsTypes, invokationContext);
+            return solveMethodAsUsage(constraintType.getBound(), name, argumentsTypes, invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedArrayType) {
             // An array inherits methods from Object not from it's component type
@@ -542,12 +550,13 @@ public class MethodCallExprContext extends ExpressionContext<MethodCallExpr> {
                     new ReferenceTypeImpl(typeSolver.getSolvedJavaLangObject()),
                     name,
                     argumentsTypes,
-                    invokationContext);
+                    invokationContext,
+                    callContext);
         }
         if (type instanceof ResolvedUnionType) {
             Optional<ResolvedReferenceType> commonAncestor = type.asUnionType().getCommonAncestor();
             if (commonAncestor.isPresent()) {
-                return solveMethodAsUsage(commonAncestor.get(), name, argumentsTypes, invokationContext);
+                return solveMethodAsUsage(commonAncestor.get(), name, argumentsTypes, invokationContext, callContext);
             }
             throw new UnsupportedOperationException("no common ancestor available for " + type.describe());
         }


### PR DESCRIPTION
## Summary

`MethodCallExprContext.solveMethodAsUsage(...)` recurses into itself and throws `StackOverflowError`
whenever a method usage is resolved against a reference type. This is a regression from
`71f74fb4` ("Method resolution has to consider call context").

That commit added a `ResolvedReferenceTypeDeclaration callContext` parameter to the private
`solveMethodAsUsage(ResolvedReferenceType, …)` overload and to the public entry points, but it did
**not** thread `callContext` through the two private *dispatcher* overloads,
`solveMethodAsUsage(ResolvedType, …)` and `solveMethodAsUsage(ResolvedTypeVariable, …)`.

As a consequence the type-dispatch branch

```java
if (type instanceof ResolvedReferenceType)
    return solveMethodAsUsage((ResolvedReferenceType) type, name, argumentsTypes, invokationContext);
```

no longer matched the (now 5-argument) `ResolvedReferenceType` overload. The compiler silently
re-bound it to the 4-argument `ResolvedType` dispatcher — i.e. the method itself — producing
unbounded self-recursion.

## Fix

Complete the threading started by fixing Java parsers method resolution:

- add `ResolvedReferenceTypeDeclaration callContext` to the private `ResolvedType` and
  `ResolvedTypeVariable` dispatcher overloads,
- pass it down every dispatch branch (so the `ResolvedReferenceType` call reaches the intended
  5-argument overload), and
- supply the call site (`invocationContext`) from the public `solveMethodAsUsage` entry point.

No behavioural change beyond fixing the recursion: the call context now reaches method resolution as
the original commit intended.

## Testing

Run against this checkout (JDK 25):

- `JavaParserFacadeTest` and `JavaParserFacadeResolutionTest`: the three `StackOverflowError`
  failures are fixed.
- `ConditionalExprTest`: two of its errors (same root cause — call context not reaching resolution)
  are fixed.
- Verified against `master` that no other test results change. The remaining unrelated failures on
  this checkout (`ConditionalExprTest.test_if_operands_have_the_same_type`,
  `ReflectionClassDeclarationTest` ancestor/interface ordering, and
  `SymbolSolverCollectionStrategyTest.resolveMultiSourceRoots`) reproduce identically on unmodified
  `master` and are out of scope here.
